### PR TITLE
throw transport exception instead of returning invalid response

### DIFF
--- a/Rpc/Exception/CurlTransportException.php
+++ b/Rpc/Exception/CurlTransportException.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @author Łukasz Pior <pior.lukasz@gmail.com>
+ */
+
+namespace Seven\RpcBundle\Rpc\Exception;
+
+use Exception;
+
+class CurlTransportException extends Exception
+{
+    public function __construct($error, $code)
+    {
+        $message = sprintf("There was a transport error with code: '%d' and message: '%s'", $code, $error);
+
+        parent::__construct($message, $code);
+    }
+}

--- a/Rpc/Transport/Curl/CurlRequest.php
+++ b/Rpc/Transport/Curl/CurlRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @author Łukasz Pior <pior.lukasz@gmail.com>
+ */
+
+namespace Seven\RpcBundle\Rpc\Transport\Curl;
+
+/**
+ * Simple wrapper around curl functions that allows us to mocks curl requests in tests
+ */
+class CurlRequest
+{
+    private $handle = null;
+
+    public function __construct()
+    {
+        $this->handle = curl_init();
+    }
+
+    public function setOptions(array $options)
+    {
+        curl_setopt_array($this->handle, $options);
+    }
+
+    public function setOption($name, $value)
+    {
+        curl_setopt($this->handle, $name, $value);
+    }
+
+    public function execute()
+    {
+        return curl_exec($this->handle);
+    }
+
+    public function getInfo($name)
+    {
+        return curl_getinfo($this->handle, $name);
+    }
+
+    public function close()
+    {
+        curl_close($this->handle);
+    }
+
+    public function getErrorNumber()
+    {
+        return curl_errno($this->handle);
+    }
+
+    public function getErrorMessage()
+    {
+        return curl_error($this->handle);
+    }
+}

--- a/Tests/Rpc/Transport/TransportCurlTest.php
+++ b/Tests/Rpc/Transport/TransportCurlTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @author Łukasz Pior <pior.lukasz@gmail.com>
+ */
+
+namespace Seven\RpcBundle\Tests\Transport;
+
+class TransportCurlTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Seven\RpcBundle\Rpc\Exception\CurlTransportException
+     *
+     * @dataProvider providerMakeRequestWithCurlError
+     */
+    public function testMakeRequestWithCurlError($errorCode, $errorMessage)
+    {
+        $transportMock = $this->getMock("Seven\\RpcBundle\\Rpc\\Transport\\TransportCurl", array(
+            "getCurlRequest"
+        ));
+
+        $requestMock = $this->getMock("Symfony\\Component\\HttpFoundation\\Request");
+
+        $curlRequestMock = $this->getMock("Seven\\RpcBundle\\Rpc\\Transport\\Curl\\CurlRequest", array(
+            "execute",
+            "getErrorNumber",
+            "getErrorMessage"
+        ));
+
+        $curlRequestMock->expects($this->once())
+            ->method('execute')
+            ->will($this->returnValue(false));
+
+        $curlRequestMock->expects($this->once())
+            ->method('getErrorNumber')
+            ->will($this->returnValue($errorCode));
+
+        $curlRequestMock->expects($this->once())
+            ->method('getErrorMessage')
+            ->will($this->returnValue($errorMessage));
+
+        $transportMock->expects($this->once())
+            ->method('getCurlRequest')
+            ->will($this->returnValue($curlRequestMock));
+
+        $transportMock->makeRequest($requestMock);
+    }
+
+    public function providerMakeRequestWithCurlError()
+    {
+        return array(
+            array(CURLE_COULDNT_CONNECT, "Failed to connect() to host or proxy."),
+            array(CURLE_OPERATION_TIMEOUTED, "Operation timeout. The specified time-out period was reached according to the conditions."),
+        );
+    }
+}


### PR DESCRIPTION
Fixes #9 

List of changes below:
- throw exception instead of returning invalid response
- added wrapper around curl_\* functions that alows us to mock them
- wrote some test that covers curl error
