### PR TITLE
Strings Being Changed to Integers

### DIFF
--- a/XmlRpc/Implementation.php
+++ b/XmlRpc/Implementation.php
@@ -306,7 +306,7 @@ class Implementation extends BaseImplementation
             return ValueType::Null;
         } elseif (is_float($value)) {
             return ValueType::Double;
-        } elseif (is_numeric($value)) {
+        } elseif (is_numeric($value) && !is_string($value)) {
             return ValueType::Integer;
         } elseif (is_bool($value)) {
             return ValueType::Boolean;


### PR DESCRIPTION
All numbers even when typecast as strings were being changed to Integers which was causing errors if the API required a number as a string, like with Benchmark's API: http://www.benchmarkemail.com/API/Doc/listAddContacts