### PR TITLE
Use is_int instead of is_numeric

### DIFF
--- a/XmlRpc/Implementation.php
+++ b/XmlRpc/Implementation.php
@@ -306,7 +306,7 @@ class Implementation extends BaseImplementation
             return ValueType::Null;
         } elseif (is_float($value)) {
             return ValueType::Double;
-        } elseif (is_numeric($value)) {
+        } elseif (is_int($value)) {
             return ValueType::Integer;
         } elseif (is_bool($value)) {
             return ValueType::Boolean;


### PR DESCRIPTION
Hi,

For some reasons, I need to keep my string. So, I replace the function to prevent the transformation of my string into integer.

For example :

In my country (France), the phone numbers begin by a zero, we need to set them in string but is_numeric function considers them as numeric and IntegerType class is used instead of StringType class. The consequence of this is that the zero is removed from phone number.

The problem with this pull request is that from now only **a real integer** will be pack into integer type.

Can you tell me what you think about this PR ?

Thanks,