### PR TITLE
Ensure fault code is numeric before returning fault.

### DIFF
--- a/JsonRpc/Implementation.php
+++ b/JsonRpc/Implementation.php
@@ -125,7 +125,10 @@ class Implementation extends BaseImplementation
                 throw new InvalidJsonRpcContent('The JSON-RPC fault code is not passed');
             }
 
-            return new MethodFault(new Fault($data['error']['message'], $data['error']['code']));
+            return is_numeric($data['error']['code'])
+                ? new MethodFault(new Fault($data['error']['message'], $data['error']['code']))
+                : new MethodFault(new Fault($data['error']['message']))
+            ;
         }
 
         throw new InvalidJsonRpcContent('The JSON-RPC response must have result or error properties');

--- a/XmlRpc/Implementation.php
+++ b/XmlRpc/Implementation.php
@@ -174,7 +174,10 @@ class Implementation extends BaseImplementation
         if ($faultEl = $xpath->query("//methodResponse/fault")->item(0)) {
             $struct = $this->extract($faultEl->firstChild);
 
-            return new MethodFault(new Fault($struct['faultString'], $struct['faultCode']));
+            return is_numeric($struct['faultCode'])
+                ? new MethodFault(new Fault($struct['faultString'], $struct['faultCode']))
+                : new MethodFault(new Fault($struct['faultString']))
+            ;
         }
 
         // extract parameters


### PR DESCRIPTION
Some rpc servers return a string instead of a code. If it's the case, I'm returning the MethodFault without the code or the application crashed with this error :

```
Error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]])
```

**Edit:** Look at this https://docs.python.org/3/library/xmlrpc.client.html#fault-objects
