### PR TITLE
Exclude tests from Composer's classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
         "phpunit/phpunit": "*"
     },
     "autoload": {
-        "psr-0": { "Seven\\RpcBundle": "" }
+        "psr-0": { "Seven\\RpcBundle": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "target-dir": "Seven/RpcBundle"
 }


### PR DESCRIPTION
This is a little performance improvement. If the optimised dumped classmap is generated, the tests should not be part of it. Excluding unit tests is [very common in Symfony's bundles](https://github.com/symfony/filesystem/blob/master/composer.json#L23-L25)

Documentation: https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps